### PR TITLE
Adiciona alias para Integer

### DIFF
--- a/lib/search_cop/visitors/visitor.rb
+++ b/lib/search_cop/visitors/visitor.rb
@@ -95,6 +95,7 @@ module SearchCop
       alias :visit_TrueClass :quote
       alias :visit_FalseClass :quote
       alias :visit_String :quote
+      alias :visit_Integer :quote
       alias :visit_Time :quote
       alias :visit_Date :quote
       alias :visit_Float :quote


### PR DESCRIPTION
# **Esse PR foi criado devido a uma necessidade na atualização do Ruby > 2.4!**

Issue: closes https://github.com/vindi/recurrent/issues/4620

Após algumas atualizações de bibliotecas nossas, queries no gateway estão retornando erro 500, com o seguinte stacktrace:

web_1    | undefined method `visit_Integer' for #<SearchCop::Visitors::Visitor:0x0000556269df7b60>
web_1    | /usr/local/bundle/bundler/gems/search_cop-0a59df0968ba/lib/search_cop/visitors/visitor.rb:15:in `visit'
web_1    | /usr/local/bundle/bundler/gems/search_cop-0a59df0968ba/lib/search_cop/visitors/visitor.rb:46:in `visit_SearchCopGrammar_Nodes_Equality'
web_1    | /usr/local/bundle/bundler/gems/search_cop-0a59df0968ba/lib/search_cop/visitors/visitor.rb:15:in `visit'
web_1    | /usr/local/bundle/bundler/gems/search_cop-0a59df0968ba/lib/search_cop/query_builder.rb:12:in `initialize'
web_1    | /usr/local/bundle/bundler/gems/search_cop-0a59df0968ba/lib/search_cop.rb:61:in `new'
web_1    | /usr/local/bundle/bundler/gems/search_cop-0a59df0968ba/lib/search_cop.rb:61:in `unsafe_search_cop'
web_1    | /usr/local/bundle/bundler/gems/search_cop-0a59df0968ba/lib/search_cop.rb:45:in `block in search_scope'
web_1    | /usr/local/bundle/gems/activerecord-5.2.4.3/lib/active_record/relation/delegation.rb:97:in `block in unsafe_api_search'
web_1    | /usr/local/bundle/gems/activerecord-5.2.4.3/lib/active_record/relation.rb:281:in `scoping'
web_1    | /usr/local/bundle/gems/activerecord-5.2.4.3/lib/active_record/relation/delegation.rb:97:in `unsafe_api_search'
web_1    | /app/app/api/v1/transactions.rb:31:in `block (2 levels) in <class:Transactions>'
web_1    | /usr/local/bundle/gems/grape-0.14.0/lib/grape/endpoint.rb:67:in `call'
web_1    | /usr/local/bundle/gems/grape-0.14.0/lib/grape/endpoint.rb:67:in `block (2 levels) in generate_api_method'
web_1    | /usr/local/bundle/gems/activesupport-5.2.4.3/lib/active_support/notifications.rb:170:in `instrument'
web_1    | /usr/local/bundle/gems/grape-0.14.0/lib/grape/endpoint.rb:66:in `block in generate_api_method'
web_1    | /usr/local/bundle/gems/grape-0.14.0/lib/grape/endpoint.rb:263:in `block in run'
web_1    | /usr/local/bundle/gems/activesupport-5.2.4.3/lib/active_support/notifications.rb:170:in `instrument'

Estou adicionando o alias `:visit_Integer`